### PR TITLE
fix compilation error from lottie-react dependency: `ReferenceError: document is not defined`

### DIFF
--- a/src/components/MainLogo.tsx
+++ b/src/components/MainLogo.tsx
@@ -1,5 +1,5 @@
-import Lottie from 'lottie-react';
 import * as React from 'react';
+import dynamic from 'next/dynamic';
 
 import {TABLET_MEDIA_QUERY} from '@/constants';
 import {Logo} from '@/icons/Logo';
@@ -9,6 +9,8 @@ import Link from 'next/link';
 import {useCSS} from '@/hooks/useCSS';
 import {useAudioManager} from '@/hooks/useAudioManager';
 import {SoundEffect} from '@/hooks/useSoundEffects';
+
+const Lottie = dynamic(() => import('lottie-react'), {ssr: false});
 
 const baseStyles: any = {
   position: 'fixed',

--- a/src/components/SplashIntro.tsx
+++ b/src/components/SplashIntro.tsx
@@ -1,7 +1,9 @@
-import Lottie from 'lottie-react';
 import * as React from 'react';
+import dynamic from 'next/dynamic';
 import * as splash from '@/animations/splash.json';
 import {useCSS} from '@/hooks/useCSS';
+
+const Lottie = dynamic(() => import('lottie-react'), {ssr: false});
 
 export const SplashIntro = ({onComplete}: {onComplete: () => void}) => {
   const css = useCSS();


### PR DESCRIPTION
the release of Node v21 (in 2023) added a [`navigator` API](https://nodejs.org/api/globals.html#navigator) (a lightweight version of `window.navigator`) by the same name. unfortunately, [`lottie-react`](https://github.com/Gamote/lottie-react) imports [`lottie-web`](https://github.com/airbnb/lottie-web), which at the time had client-side guards that checked for
`typeof navigator !== "undefined"` instead of for `window`.

```
ReferenceError: document is not defined
    at createTag
(node_modules/lottie-web/build/player/lottie.js:30:5)
```

it was first reported in 2023:

- https://github.com/airbnb/lottie-web/issues/3047
- https://github.com/airbnb/lottie-web/issues/2739

it was fixed the following year, airbnb/lottie-web#3133, but the maintainer of `lottie-react` still hasn't released a new version that bumps the `lottie-web` dependency. it's either fork the project or this not-terrible workaround. regardless, it would be a wise performance improvement for lightening page loads.